### PR TITLE
[bugfix] Dont go out of bound if people are too old.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RateTables"
 uuid = "d40fb65e-c2ee-4113-9e14-cb96ca0acb32"
 authors = ["Oskar Laverny <oskar.laverny@univ-amu.fr> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/RateTable.jl
+++ b/src/RateTable.jl
@@ -102,7 +102,7 @@ Base.getindex(rt::RateTable, args...)   = rt.map[args]
 Base.getindex(rt::RateTable; kwargs...) = getindex(rt, collect(kwargs[n] for n in keys(rt.axes))...)
 
 # Helper function. 
-dty(t,minval,maxval) = min(Int(trunc(t*RT_YEARS_IN_DAY))-minval+1,maxval-minval+1)
+dty(t,minval,maxval) = max(min(Int(trunc(t*RT_YEARS_IN_DAY))-minval+1,maxval-minval+1),1)
 
 """
     daily_hazard(rt::BasicRateTable, age, date)

--- a/src/RateTable.jl
+++ b/src/RateTable.jl
@@ -102,7 +102,7 @@ Base.getindex(rt::RateTable, args...)   = rt.map[args]
 Base.getindex(rt::RateTable; kwargs...) = getindex(rt, collect(kwargs[n] for n in keys(rt.axes))...)
 
 # Helper function. 
-dty(t,minval,maxval) = max(min(Int(trunc(t*RT_YEARS_IN_DAY))-minval+1,maxval-minval+1),1)
+dty(t,minval,maxval) = clamp(Int(trunc(t*RT_YEARS_IN_DAY))-minval+1, 1, maxval-minval+1)
 
 """
     daily_hazard(rt::BasicRateTable, age, date)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,10 @@ using RData
             @test e+a <= 120*365.241
         end
     end
+
+    @testset "Dont go out of bound" begin
+        daily_hazard(survexp_fr[:male], 20*365.241, (survexp_fr[:male].extrema_year[1]-1)*365.241+12)
+    end
 end
 
 


### PR DESCRIPTION
When people are too old for the life table, this PR added a simple approximation by clamping them into the time frame.

This is an approximation, but should be good enough for people that are not too far. This allows to always give a rate whatever the person, even if it is a bit approximated. 